### PR TITLE
Add libglib2.0-dev to dependencies installation

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          sudo apt-get install -y meson libbsd-dev
+          sudo apt-get install -y meson libbsd-dev libglib2.0-dev
 
       - name: Checkout libcli
         uses: actions/checkout@v3

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -74,7 +74,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          sudo apt-get install -y meson libbsd-dev
+          sudo apt-get install -y meson libbsd-dev libglib2.0-dev
 
       - name: Checkout libcli
         uses: actions/checkout@v3


### PR DESCRIPTION
Looks like the development package of glib2 was moved out of the base installation.